### PR TITLE
Feature/disable rtabmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ ros-melodic-geometric-shapes \
 ros-melodic-object-recognition-msgs \
 ros-melodic-octomap \
 ros-melodic-octomap-msgs \
+ros-melodic-octomap-ros \
+ros-melodic-octomap-server \
 ros-melodic-random-numbers \
 ros-melodic-srdfdom \
 ros-melodic-ros-control \

--- a/robowork_base/config/costmap_common_SIM.yaml
+++ b/robowork_base/config/costmap_common_SIM.yaml
@@ -2,8 +2,8 @@ footprint: [[-0.325, -0.375], [-0.325, 0.375], [0.325, 0.375], [0.325, -0.375]]
 footprint_padding: 0.025  #0.01
 
 robot_base_frame: bvr_SIM/bvr_base_link
-update_frequency: 4.0
-publish_frequency: 3.0
+update_frequency: 2.0
+publish_frequency: 2.0
 transform_tolerance: 0.5
 
 resolution: 0.05
@@ -14,6 +14,10 @@ raytrace_range: 6.0
 #layer definitions
 static_map_layer:
     map_topic: rtabmap/grid_map
+    subscribe_to_updates: true
+
+static_map_layer:
+    map_topic: projected_map
     subscribe_to_updates: true
 
 obstacles_layer:

--- a/robowork_base/config/costmap_global_laser_SIM.yaml
+++ b/robowork_base/config/costmap_global_laser_SIM.yaml
@@ -1,8 +1,8 @@
 global_frame: map #bvr_SIM/odom
 rolling_window: true
-track_unknown_space: true
+track_unknown_space: false
 
 plugins:
   - {name: static_map_layer,  type: "costmap_2d::StaticLayer"}
   - {name: inflation_layer,  type: "costmap_2d::InflationLayer"}
-  - {name: obstacles_layer,  type: "costmap_2d::ObstacleLayer"}
+#  - {name: obstacles_layer,  type: "costmap_2d::ObstacleLayer"}

--- a/robowork_base/config/costmap_global_static_SIM.yaml
+++ b/robowork_base/config/costmap_global_static_SIM.yaml
@@ -1,6 +1,6 @@
 global_frame: map
-rolling_window: false
-track_unknown_space: true
+rolling_window: true
+track_unknown_space: false
 
 plugins:
   - {name: static_map_layer,  type: "costmap_2d::StaticLayer"}

--- a/robowork_base/config/costmap_local_SIM.yaml
+++ b/robowork_base/config/costmap_local_SIM.yaml
@@ -1,5 +1,6 @@
 global_frame: map #bvr_SIM/odom
 rolling_window: true
+track_unknown_space: false
 
 plugins:
   - {name: static_map_layer,  type: "costmap_2d::StaticLayer"}

--- a/robowork_gazebo/launch/bvr_SIM_playpen.launch
+++ b/robowork_gazebo/launch/bvr_SIM_playpen.launch
@@ -4,6 +4,7 @@
   <arg name="robot_namespace" default="bvr_SIM"/>
   <arg name="arm_namespace" default="main_arm_SIM"/>
   <arg name="VIO_enabled" default="true"/>
+  <arg name="use_gazebo_odom" default="true"/>
 
   <arg name="robot_initial_x" default="0.0"/>
   <arg name="robot_initial_y" default="0.0"/>
@@ -42,6 +43,7 @@
 
   <include file="$(find robowork_gazebo)/launch/spawn_bvr_SIM_robot.launch">
     <arg name="VIO_enabled" value="$(arg VIO_enabled)"/>
+    <arg name="use_gazebo_odom" value="$(arg use_gazebo_odom)"/>
     <arg name="robot_initial_x" value="$(arg robot_initial_x)"/>
     <arg name="robot_initial_y" value="$(arg robot_initial_y)"/>
     <arg name="robot_initial_z" value="$(arg robot_initial_z)"/>

--- a/robowork_gazebo/launch/spawn_bvr_SIM_robot.launch
+++ b/robowork_gazebo/launch/spawn_bvr_SIM_robot.launch
@@ -15,6 +15,7 @@
   <arg name="ur5_e_robot_prefix" default="main_arm_SIM/"/> #""
   <arg name="sim_suffix" default="_SIM"/> #
   <arg name="VIO_enabled" default="false"/>
+  <arg name="use_gazebo_odom" default="true"/>
 
   <arg name="base_controllers" default="$(arg robot_namespace)_joint_state_controller $(arg robot_namespace)_velocity_controller"/>
   <arg name="main_arm_controllers" default="$(arg arm_namespace)/compliance_controller"/> #handle this here for simulation
@@ -77,10 +78,18 @@
     </node>
     <!-- <node name="$(arg robot_namespace)_tf_connect_SIM" pkg="robowork_perception" type="tf_connect_SIM.py" output="log"/> -->
     <!-- RTABMAP -->
-    <include file="$(find robowork_base)/launch/realsense_rtabmap.launch">
+    <include unless="$(arg use_gazebo_odom)" file="$(find robowork_base)/launch/realsense_rtabmap.launch">
       <arg name="robot_namespace" value="$(arg robot_namespace)"/>
       <arg name="arm_namespace" value="$(arg arm_namespace)"/>
     </include>
+    <!-- OCTOMAP for static_map_layer of move_base costmap when RTABMAP is disabled -->
+    <node if="$(arg use_gazebo_odom)" name="octomap_server" pkg="octomap_server" type="octomap_server_node">
+      <remap from="cloud_in" to="/$(arg robot_namespace)/l515/depth/color/points"/>
+      <param name="resolution" value="0.1"/>
+      <param name="frame_id" value="map"/>
+      <param name="sensor_model/max_range" value="5.0"/>
+      <param name="pointcloud_min_z" value="0.1"/>
+    </node>
 
     <!-- Perception -->
     <include file="$(find robowork_perception)/launch/apriltag_detection.launch">
@@ -97,7 +106,7 @@
       <arg name="robot_namespace" value="$(arg robot_namespace)"/>
       <arg name="arm_namespace" value="$(arg arm_namespace)"/>
       <arg name="sim_suffix" value="$(arg sim_suffix)"/>
-      <arg name="static_map" value="true"/>
+      <arg name="static_map" value="false"/>
     </include>
 
     <!-- Spawn gazebo model -->

--- a/robowork_moveit_config/launch/moveit.rviz
+++ b/robowork_moveit_config/launch/moveit.rviz
@@ -131,14 +131,14 @@ Visualization Manager:
           Value: true
         - Alpha: 0.699999988079071
           Class: rviz/Map
-          Color Scheme: map
+          Color Scheme: raw
           Draw Behind: false
-          Enabled: false
+          Enabled: true
           Name: GlobalCostmap_SIM
           Topic: /bvr_SIM/move_base/global_costmap/costmap
           Unreliable: false
           Use Timestamp: false
-          Value: false
+          Value: true
         - Alpha: 0.699999988079071
           Class: rviz/Map
           Color Scheme: costmap
@@ -191,7 +191,7 @@ Visualization Manager:
           Topic: /bvr_SIM/odom
           Unreliable: false
           Value: true
-      Enabled: false
+      Enabled: true
       Name: Plan_SIM
     - Class: rviz/TF
       Enabled: false
@@ -373,8 +373,8 @@ Visualization Manager:
     - Alpha: 1
       Autocompute Intensity Bounds: true
       Autocompute Value Bounds:
-        Max Value: 1.573434829711914
-        Min Value: 0.05172371864318848
+        Max Value: 2.3788955211639404
+        Min Value: 0.008504688739776611
         Value: true
       Axis: Z
       Channel Name: intensity
@@ -396,6 +396,44 @@ Visualization Manager:
       Size (m): 0.05000000074505806
       Style: Points
       Topic: /bvr_SIM/rtabmap/cloud_map
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: false
+      Marker Topic: /bvr_SIM/occupied_cells_vis_array
+      Name: Octomap_Occupied_SIM
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: false
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 0.75
+        Min Value: 0.15000000596046448
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: AxisColor
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: Octomap_PointCloud2_SIM
+      Position Transformer: XYZ
+      Queue Size: 1
+      Selectable: true
+      Size (Pixels): 2
+      Size (m): 0.05000000074505806
+      Style: Points
+      Topic: /bvr_SIM/octomap_point_cloud_centers
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true
@@ -428,25 +466,25 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/XYOrbit
-      Distance: 3.0884792804718018
+      Distance: 2.848625898361206
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: 0.46466708183288574
-        Y: 0.06874591112136841
-        Z: 8.348304618266411e-6
+        X: 0.47711336612701416
+        Y: 0.5028002858161926
+        Z: 8.944351066020317e-6
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.38979798555374146
+      Pitch: 0.5047978758811951
       Target Frame: base_footprint
       Value: XYOrbit (rviz)
-      Yaw: 2.3035387992858887
+      Yaw: 2.503535270690918
     Saved: ~
 Window Geometry:
   Displays:


### PR DESCRIPTION
Disable use of rtabmap optionally and rely completely on gazebo generated odom.

Also accounts for the need to generate gridmaps for move_base.